### PR TITLE
Add extra clarity for versionNumber usage

### DIFF
--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Resonite/Directory.Build.targets
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Resonite/Directory.Build.targets
@@ -1,4 +1,9 @@
 <Project>
+  
+  <!--
+    Build Thunderstore package by calling `dotnet build -c Release -target:PackTS -v d` (verbosity detailed).
+    Publish to Thunderstore by including `-property:PublishTS=true` in the command.
+  -->
   <Target Name="PackTS" DependsOnTargets="Build">
     <CallTarget Targets="PackTS_Execute" Condition="'$(ThunderstorePackable)' == 'true' and '$(Configuration)' == 'Release'" />
   </Target>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Resonite/thunderstore.toml
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Resonite/thunderstore.toml
@@ -6,7 +6,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "{firstAuthor}" # TODO: Change this to the team you're uploading the mod to on Thunderstore
 name = "ProjectName" # Change this to your mod's name, no spaces or special characters, max 128 characters
-# versionNumber = "{version}" # Uncomment this if using publishing via manual tcli! Change this to your mod's version, must be in semantic versioning format (e.g. 1.0.0, 2.1.3, 0.1.0-alpha.1)
+# versionNumber = "{version}" # Uncomment this if publishing via manual tcli! Change this to your mod's version, must be in semantic versioning format (e.g. 1.0.0, 2.1.3, 0.1.0-alpha.1)
 description = "Example mod description" # TODO: Change this to your mod's description, max 250 characters
 websiteUrl = "{repositoryUrl}" # TODO: Change this to your mod's website/repository, or leave blank
 containsNsfwContent = false

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Resonite/thunderstore.toml
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Resonite/thunderstore.toml
@@ -6,14 +6,14 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "{firstAuthor}" # TODO: Change this to the team you're uploading the mod to on Thunderstore
 name = "ProjectName" # Change this to your mod's name, no spaces or special characters, max 128 characters
-versionNumber = "{version}" # Change this to your mod's version, must be in semantic versioning format (e.g. 1.0.0, 2.1.3, 0.1.0-alpha.1), Only read during manual usage of tcli.
+# versionNumber = "{version}" # Uncomment this if using publishing via manual tcli! Change this to your mod's version, must be in semantic versioning format (e.g. 1.0.0, 2.1.3, 0.1.0-alpha.1)
 description = "Example mod description" # TODO: Change this to your mod's description, max 250 characters
 websiteUrl = "{repositoryUrl}" # TODO: Change this to your mod's website/repository, or leave blank
 containsNsfwContent = false
 
 # List any dependencies your mod has here, in the format "namespace-modname" = "version-constraint"
 [package.dependencies] 
-ResoniteModding-BepisLoader = "1.3.1"
+ResoniteModding-BepisLoader = "1.4.1"
 ResoniteModding-BepisResoniteWrapper = "1.0.0"
 
 [build]


### PR DESCRIPTION
This PR adds the comment from https://github.com/PEAKModding/BepInExTemplate/blob/d20665fe612515b84f84faa4eee8d4add40480d2/content/BepInExModTemplate/Directory.Build.targets#L50 to show what the build command does

Comments out the versionNumber in the thunderstore.toml while adding a disclaimer to uncomment it if manually publishing via tcli

This prevents confusion and prevents searching many places for changing the version number